### PR TITLE
4 terraform random provider

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/random" {
+  version     = "3.5.1"
+  constraints = "3.5.1"
+  hashes = [
+    "h1:IL9mSatmwov+e0+++YX2V6uel+dV6bn+fC/cnGDK3Ck=",
+    "zh:04e3fbd610cb52c1017d282531364b9c53ef72b6bc533acb2a90671957324a64",
+    "zh:119197103301ebaf7efb91df8f0b6e0dd31e6ff943d231af35ee1831c599188d",
+    "zh:4d2b219d09abf3b1bb4df93d399ed156cadd61f44ad3baf5cf2954df2fba0831",
+    "zh:6130bdde527587bbe2dcaa7150363e96dbc5250ea20154176d82bc69df5d4ce3",
+    "zh:6cc326cd4000f724d3086ee05587e7710f032f94fc9af35e96a386a1c6f2214f",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:b6d88e1d28cf2dfa24e9fdcc3efc77adcdc1c3c3b5c7ce503a423efbdd6de57b",
+    "zh:ba74c592622ecbcef9dc2a4d81ed321c4e44cddf7da799faa324da9bf52a22b2",
+    "zh:c7c5cde98fe4ef1143bd1b3ec5dc04baf0d4cc3ca2c5c7d40d17c0e9b2076865",
+    "zh:dac4bad52c940cd0dfc27893507c1e92393846b024c5a9db159a93c534a3da03",
+    "zh:de8febe2a2acd9ac454b844a4106ed295ae9520ef54dc8ed2faf29f12716b602",
+    "zh:eab0d0495e7e711cca367f7d4df6e322e6c562fc52151ec931176115b83ed014",
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -8,3 +8,48 @@ The versioning uses the format **MAJOR.MINOR.PATCH** e.g **1.0.1**
 - **MAJOR** version when you make incompatible API changes
 - **MINOR** version when you add functionality in a backward compatible manner
 - **PATCH** version when you make backward compatible bug fixes
+
+
+
+## Terraform Basics 
+
+### Terraform Registry 
+
+Terraform sources are Providers and Modules from the Terraform Registry located at [registry.terraform.io](https://registry.terraform.io/)
+- **Providers**: A Terraform provider is a plugin that enables Terraform interact with external services. 
+    - Examples of Terraform providers include AWS, GCP, Azure, Kubernetes, Oracle, Random etc. 
+- **Modules**: A Terraform module is simply a directory containing Terraform configuration 
+
+N/B: For this particular PR, the [Random](https://registry.terraform.io/providers/hashicorp/random/) provider was used. The Random provider generates a random identifier that can be used in Terraform modules for naming resources. 
+
+
+#### Terraform CLI 
+Run `terraform` to see all the Terraform commands. 
+
+#### Terraform Init
+`terraform init`    
+This would download the binaries of Terraform providers that are declared in the Terraform module. 
+
+#### Terraform Plan
+Running `terraform plan` will generate a change set of resources and what will be changed once executed. The changeset can be passed to apply which would then execute.
+
+#### Terraform Apply 
+`terraform apply`    
+This would plan and pass the changesets to be executed by terraform. Running `terraform apply` will prompt `yes` or `no`. To automatically run `terraform apply` without the prompt, run `terraform apply --auto-approve`. 
+
+#### Terraform Lock Files 
+`.terraform.lock.hcl` contains the locked versioning for the providers or modules that should be used with this project.    
+
+The Terraform Lock File should be committed to Version Control.
+
+
+#### Terraform State Files 
+`.terraform.tfstate` contains information about the current state of your infrastructure.   
+
+This file **should not be committed to Version Control** as this file can contain sensitive data. Losing this file means losing the state of your infrastructure. 
+
+`.terraform.tfstate.backup` is the previous state file. 
+
+
+#### Terraform Directory 
+The directory that contains the downloaded binaries of the Terraform Providers. 

--- a/main.tf
+++ b/main.tf
@@ -1,1 +1,23 @@
-# First code change
+terraform {
+  required_providers {
+    random = {
+      source = "hashicorp/random"
+      version = "3.5.1"
+    }
+  }
+}
+
+provider "random" {
+  # Configuration options
+}
+
+resource "random_string" "bucket_name" {
+  length           = 16
+  special          = false
+
+}
+
+output "random_bucket_name_result" {
+    value = random_string.bucket_name.result
+    
+}


### PR DESCRIPTION
### What does this PR do?
- Implement Random Bucket Name in Terraform.
- Write docs for Topics and Commands.

### What tasks were done?
- Install `Random` Terraform provider.
- Write Terraform configuration for Random Bucket name generation 
- Write documentation for Terraform Modules, Providers, Statefiles, and Lockfiles. 

Fixes #6 